### PR TITLE
Replace PWA service worker with kill-switch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -145,7 +145,7 @@ assets:
 pwa:
   enabled: false # The option for PWA feature (installable)
   cache:
-    enabled: true # The option for PWA offline cache
+    enabled: false # The option for PWA offline cache
     # Paths defined here will be excluded from the PWA cache.
     # Usually its value is the `baseurl` of another website that
     # shares the same domain name as the current website.

--- a/sw.min.js
+++ b/sw.min.js
@@ -1,0 +1,18 @@
+// Kill-switch service worker. Replaces Chirpy's PWA cache SW that used to
+// be served at this path. When an old browser does its periodic update
+// check, it fetches this file, sees new bytes, installs this version,
+// and on activate it wipes its caches and unregisters itself.
+// Safe to delete once enough time has passed that no returning visitor
+// could plausibly still have the old SW installed (~6-12 months).
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    await self.registration.unregister();
+    const clients = await self.clients.matchAll();
+    clients.forEach((c) => c.navigate(c.url));
+  })());
+});


### PR DESCRIPTION
## Summary

- Disables Chirpy's offline cache (`pwa.cache.enabled: false`)
- Adds `sw.min.js` at the repo root containing a self-destructing service worker that replaces Chirpy's old one at the same URL

## Why

Issue #3: stale SW caches the homepage and hides new posts. Just disabling PWA isn't enough because anyone who's already visited the site has the old SW installed and it lives forever until something replaces it. A 404 on `/sw.min.js` doesn't kill it — browsers ignore failed update fetches. The kill-switch is bytes that *are* served at that URL, so when browsers do their periodic update check they install the new SW, which wipes its caches and unregisters itself on activate.

## Test plan

- [x] CI build passes (will catch any path conflict between this `sw.min.js` and the theme's)
- [x] After merge: `curl https://kevinpanko.xyz/sw.min.js` returns the kill-switch (with the comment header), not Chirpy's cache code
- [ ] After merge: in a browser that previously had the Chirpy SW installed, DevTools → Application → Service Workers eventually shows it as redundant or absent (within ~24h, the SW update window)
- [ ] Publish a new post a few days later and confirm it appears without manual cache clearing